### PR TITLE
Convert server to use FastAPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.10"
 dependencies = [
   "diskcache",
   "duckdb>=1.3.0",
-  "falcon>=3.1.1",
+  "fastapi>=0.111.0",
   "uvicorn>=0.24.0",
   "pandas",
   "pyarrow",


### PR DESCRIPTION
Convert the server implementation from Falcon to FastAPI, maintaining existing API behavior and functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-cc1fa50f-ee16-4079-8f0c-da90ef69b240">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cc1fa50f-ee16-4079-8f0c-da90ef69b240">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

